### PR TITLE
Add navbar to coach pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,18 +21,13 @@ import BlogList from './Pages/Coach/Blog/BlogList';
 import BlogCreate from './Pages/Coach/Blog/BlogCreate';
 import BlogView from './Pages/Coach/Blog/BlogView';
 
-// Wrapper component to conditionally render Navbar
-const Layout = ({ children }) => {
-  const location = useLocation();
-  const isCoachRoute = location.pathname.startsWith('/coach');
-
-  return (
-    <>
-      {!isCoachRoute && <Navbar />}
-      {children}
-    </>
-  );
-};
+// Layout component used to wrap all routes with the common Navbar
+const Layout = ({ children }) => (
+  <>
+    <Navbar />
+    {children}
+  </>
+);
 
 function App() {
   return (

--- a/src/Pages/Coach/CoachLayout.jsx
+++ b/src/Pages/Coach/CoachLayout.jsx
@@ -15,7 +15,7 @@ const CoachLayout = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white flex">
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white flex pt-20">
       {/* Sidebar */}
       <aside
         className={`fixed inset-y-0 left-0 z-50 w-64 bg-white dark:bg-gray-800 shadow-lg transform 


### PR DESCRIPTION
## Summary
- show the shared `Navbar` on coach routes by default
- add padding to the coach layout so content isn't hidden behind the navbar

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f6c6891448332aa7dc6bdb3284f4f